### PR TITLE
Fix PointerPursuit result label string formatting

### DIFF
--- a/minigames/PointerPursuit/PointerPursuit.gd
+++ b/minigames/PointerPursuit/PointerPursuit.gd
@@ -139,8 +139,8 @@ func end_minigame(won: bool, message: String):
 	score_label.text = "Puntos: %d" % final_score
 	status_label.text = won ? "Estado: ¡Sobreviviste!" : "Estado: Fin del juego"
 
-	result_label.visible = true
-	result_label.text = "%s\nPuntuación: %d" % [message, final_score]
+result_label.visible = true
+result_label.text = message + "\nPuntuación: " + str(final_score)
 
 	await get_tree().create_timer(2.0).timeout
 	GameManager.complete_minigame(won, final_score)


### PR DESCRIPTION
## Summary
- replace the PointerPursuit result label formatting with a Godot 4 compatible string build to avoid the array-based % syntax

## Testing
- `godot4 --headless --check-only minigames/PointerPursuit/PointerPursuit.tscn` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d12caa5564832db2b2e47c5e2af59e