### PR TITLE
Improve DodgeTheDrop UI presentation

### DIFF
--- a/minigames/DodgeTheDrop/DodgeTheDrop.tscn
+++ b/minigames/DodgeTheDrop/DodgeTheDrop.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=6 format=3 uid="uid://bln2yok6epjbf"]
+[gd_scene load_steps=9 format=3 uid="uid://bln2yok6epjbf"]
 
 [ext_resource type="Script" uid="uid://dpochmmrkk1pr" path="res://minigames/DodgeTheDrop/dodge_the_drop.gd" id="1_ukd48"]
 [ext_resource type="Script" uid="uid://dpett0n2bdxsn" path="res://minigames/DodgeTheDrop/player.gd" id="2_ugcg6"]
@@ -7,6 +7,42 @@
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_x67ft"]
 size = Vector2(16, 16)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_1b7xq"]
+bg_color = Color(0.066667, 0.066667, 0.105882, 0.854902)
+border_color = Color(0.192157, 0.533333, 0.843137, 1)
+border_width_bottom = 2
+border_width_left = 2
+border_width_right = 2
+border_width_top = 2
+corner_radius_bottom_left = 12
+corner_radius_bottom_right = 12
+corner_radius_top_left = 12
+corner_radius_top_right = 12
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_kjkbm"]
+bg_color = Color(0.043137, 0.043137, 0.066667, 0.87451)
+border_color = Color(0.866667, 0.639216, 0.152941, 1)
+border_width_bottom = 3
+border_width_left = 3
+border_width_right = 3
+border_width_top = 3
+corner_radius_bottom_left = 16
+corner_radius_bottom_right = 16
+corner_radius_top_left = 16
+corner_radius_top_right = 16
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_xx4tf"]
+bg_color = Color(0.043137, 0.043137, 0.066667, 0.862745)
+border_color = Color(0.192157, 0.533333, 0.843137, 1)
+border_width_bottom = 3
+border_width_left = 3
+border_width_right = 3
+border_width_top = 3
+corner_radius_bottom_left = 16
+corner_radius_bottom_right = 16
+corner_radius_top_left = 16
+corner_radius_top_right = 16
 
 [node name="DodgeTheDrop" type="Node2D"]
 script = ExtResource("1_ukd48")
@@ -26,15 +62,65 @@ texture = ExtResource("3_crrl4")
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Player"]
 shape = SubResource("RectangleShape2D_x67ft")
 
-[node name="ScoreLabel" type="Label" parent="."]
-offset_right = 40.0
-offset_bottom = 23.0
+[node name="UI" type="CanvasLayer" parent="."]
+layer = 1
 
-[node name="ResultLabel" type="Label" parent="."]
-visible = false
-offset_left = 320.0
-offset_top = 360.0
-offset_right = 360.0
-offset_bottom = 383.0
+[node name="UIRoot" type="Control" parent="UI"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="ScorePanel" type="PanelContainer" parent="UI/UIRoot"]
+offset_left = 24.0
+offset_top = 24.0
+offset_right = 284.0
+offset_bottom = 104.0
+theme_override_styles/panel = SubResource("StyleBoxFlat_1b7xq")
+
+[node name="ScoreLabel" type="Label" parent="UI/UIRoot/ScorePanel"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 34
+theme_override_colors/font_color = Color(0.866667, 0.952941, 1, 1)
+text = "Puntuación: 0"
 horizontal_alignment = 1
 vertical_alignment = 1
+
+[node name="StartPanel" type="PanelContainer" parent="UI/UIRoot"]
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = -270.0
+offset_top = -188.0
+offset_right = 270.0
+offset_bottom = -44.0
+theme_override_styles/panel = SubResource("StyleBoxFlat_xx4tf")
+
+[node name="StartLabel" type="Label" parent="UI/UIRoot/StartPanel"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 28
+theme_override_colors/font_color = Color(0.866667, 0.952941, 1, 1)
+text = "¡Mueve el ratón y esquiva las rocas!"
+horizontal_alignment = 1
+vertical_alignment = 1
+autowrap_mode = 1
+
+[node name="ResultPanel" type="PanelContainer" parent="UI/UIRoot"]
+visible = false
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -300.0
+offset_top = -110.0
+offset_right = 300.0
+offset_bottom = 110.0
+theme_override_styles/panel = SubResource("StyleBoxFlat_kjkbm")
+
+[node name="ResultLabel" type="Label" parent="UI/UIRoot/ResultPanel"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 36
+theme_override_colors/font_color = Color(1, 0.909804, 0.678431, 1)
+text = "¡Superaste la tormenta!\nPuntuación final: 0"
+horizontal_alignment = 1
+vertical_alignment = 1
+autowrap_mode = 1

--- a/minigames/DodgeTheDrop/DodgeTheDrop.tscn
+++ b/minigames/DodgeTheDrop/DodgeTheDrop.tscn
@@ -10,39 +10,39 @@ size = Vector2(16, 16)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_1b7xq"]
 bg_color = Color(0.066667, 0.066667, 0.105882, 0.854902)
-border_color = Color(0.192157, 0.533333, 0.843137, 1)
-border_width_bottom = 2
 border_width_left = 2
-border_width_right = 2
 border_width_top = 2
-corner_radius_bottom_left = 12
-corner_radius_bottom_right = 12
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.192157, 0.533333, 0.843137, 1)
 corner_radius_top_left = 12
 corner_radius_top_right = 12
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_kjkbm"]
-bg_color = Color(0.043137, 0.043137, 0.066667, 0.87451)
-border_color = Color(0.866667, 0.639216, 0.152941, 1)
-border_width_bottom = 3
-border_width_left = 3
-border_width_right = 3
-border_width_top = 3
-corner_radius_bottom_left = 16
-corner_radius_bottom_right = 16
-corner_radius_top_left = 16
-corner_radius_top_right = 16
+corner_radius_bottom_right = 12
+corner_radius_bottom_left = 12
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_xx4tf"]
 bg_color = Color(0.043137, 0.043137, 0.066667, 0.862745)
-border_color = Color(0.192157, 0.533333, 0.843137, 1)
-border_width_bottom = 3
 border_width_left = 3
-border_width_right = 3
 border_width_top = 3
-corner_radius_bottom_left = 16
-corner_radius_bottom_right = 16
+border_width_right = 3
+border_width_bottom = 3
+border_color = Color(0.192157, 0.533333, 0.843137, 1)
 corner_radius_top_left = 16
 corner_radius_top_right = 16
+corner_radius_bottom_right = 16
+corner_radius_bottom_left = 16
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_kjkbm"]
+bg_color = Color(0.043137, 0.043137, 0.066667, 0.87451)
+border_width_left = 3
+border_width_top = 3
+border_width_right = 3
+border_width_bottom = 3
+border_color = Color(0.866667, 0.639216, 0.152941, 1)
+corner_radius_top_left = 16
+corner_radius_top_right = 16
+corner_radius_bottom_right = 16
+corner_radius_bottom_left = 16
 
 [node name="DodgeTheDrop" type="Node2D"]
 script = ExtResource("1_ukd48")
@@ -63,13 +63,15 @@ texture = ExtResource("3_crrl4")
 shape = SubResource("RectangleShape2D_x67ft")
 
 [node name="UI" type="CanvasLayer" parent="."]
-layer = 1
 
 [node name="UIRoot" type="Control" parent="UI"]
+layout_mode = 3
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 
 [node name="ScorePanel" type="PanelContainer" parent="UI/UIRoot"]
+layout_mode = 0
 offset_left = 24.0
 offset_top = 24.0
 offset_right = 284.0
@@ -78,13 +80,14 @@ theme_override_styles/panel = SubResource("StyleBoxFlat_1b7xq")
 
 [node name="ScoreLabel" type="Label" parent="UI/UIRoot/ScorePanel"]
 layout_mode = 2
-theme_override_font_sizes/font_size = 34
 theme_override_colors/font_color = Color(0.866667, 0.952941, 1, 1)
+theme_override_font_sizes/font_size = 34
 text = "Puntuación: 0"
 horizontal_alignment = 1
 vertical_alignment = 1
 
 [node name="StartPanel" type="PanelContainer" parent="UI/UIRoot"]
+layout_mode = 0
 anchor_left = 0.5
 anchor_top = 1.0
 anchor_right = 0.5
@@ -97,15 +100,16 @@ theme_override_styles/panel = SubResource("StyleBoxFlat_xx4tf")
 
 [node name="StartLabel" type="Label" parent="UI/UIRoot/StartPanel"]
 layout_mode = 2
-theme_override_font_sizes/font_size = 28
 theme_override_colors/font_color = Color(0.866667, 0.952941, 1, 1)
-text = "¡Mueve el ratón y esquiva las rocas!"
+theme_override_font_sizes/font_size = 28
+text = "¡Usa Q o E ,  y esquiva las rocas!"
 horizontal_alignment = 1
 vertical_alignment = 1
 autowrap_mode = 1
 
 [node name="ResultPanel" type="PanelContainer" parent="UI/UIRoot"]
 visible = false
+layout_mode = 0
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -118,9 +122,10 @@ theme_override_styles/panel = SubResource("StyleBoxFlat_kjkbm")
 
 [node name="ResultLabel" type="Label" parent="UI/UIRoot/ResultPanel"]
 layout_mode = 2
-theme_override_font_sizes/font_size = 36
 theme_override_colors/font_color = Color(1, 0.909804, 0.678431, 1)
-text = "¡Superaste la tormenta!\nPuntuación final: 0"
+theme_override_font_sizes/font_size = 36
+text = "¡Superaste la tormenta!
+Puntuación final: 0"
 horizontal_alignment = 1
 vertical_alignment = 1
 autowrap_mode = 1

--- a/minigames/DodgeTheDrop/dodge_the_drop.gd
+++ b/minigames/DodgeTheDrop/dodge_the_drop.gd
@@ -1,8 +1,10 @@
 extends Node2D
 
 @onready var player = $Player
-@onready var score_label: Label = $ScoreLabel
-@onready var result_label: Label = $ResultLabel
+@onready var score_label: Label = $UI/UIRoot/ScorePanel/ScoreLabel
+@onready var start_panel: Control = $UI/UIRoot/StartPanel
+@onready var result_panel: Control = $UI/UIRoot/ResultPanel
+@onready var result_label: Label = $UI/UIRoot/ResultPanel/ResultLabel
 @export var obstacle_scene: PackedScene
 var is_game_active := false
 var time_left := 10.0
@@ -10,11 +12,12 @@ var score := 0.0
 var obstacle_timer: Timer
 
 func _ready():
-	Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
-	GameManager.start_countdown_timer(time_left, _on_minigame_timeout)
-	is_game_active = true
-	# print("Dificultad: %d" % GameManager.get_difficulty())
-	spawn_obstacles()
+        Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
+        GameManager.start_countdown_timer(time_left, _on_minigame_timeout)
+        is_game_active = true
+        # print("Dificultad: %d" % GameManager.get_difficulty())
+        spawn_obstacles()
+        _show_start_message()
 
 func spawn_obstacles():
 	obstacle_timer = Timer.new()
@@ -45,15 +48,24 @@ func _on_minigame_timeout():
 	end_game(true)
 	
 func _process(delta):
-	if is_game_active:
-		score += 100.0 / time_left * delta
-		score = clamp(score, 0.0, 100.0)
-		score_label.text = "Puntos: " + str(round(score))
-	
+        if is_game_active:
+                score += 100.0 / time_left * delta
+                score = clamp(score, 0.0, 100.0)
+                score_label.text = "Puntuación: " + str(round(score))
+
 func end_game(won: bool):
-	is_game_active = false
-	var final_score = round(score)
-	# Mostrar cartel centrado
-	result_label.text = "¡Has ganado %d puntos!" % final_score
-	result_label.visible = true
-	GameManager.complete_minigame(won, final_score)
+        is_game_active = false
+        var final_score = round(score)
+        # Mostrar cartel centrado
+        var headline := won ? "¡Superaste la tormenta!" : "¡Ups! ¡Te alcanzó una roca!"
+        result_label.text = "%s\nPuntuación final: %d" % [headline, final_score]
+        result_panel.visible = true
+        start_panel.visible = false
+        GameManager.complete_minigame(won, final_score)
+
+func _show_start_message():
+        start_panel.visible = true
+        var timer := get_tree().create_timer(2.0)
+        timer.timeout.connect(func():
+                start_panel.visible = false
+        )

--- a/minigames/DodgeTheDrop/dodge_the_drop.gd
+++ b/minigames/DodgeTheDrop/dodge_the_drop.gd
@@ -12,12 +12,14 @@ var score := 0.0
 var obstacle_timer: Timer
 
 func _ready():
-        Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
-        GameManager.start_countdown_timer(time_left, _on_minigame_timeout)
-        is_game_active = true
-        # print("Dificultad: %d" % GameManager.get_difficulty())
-        spawn_obstacles()
-        _show_start_message()
+		Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
+		_show_start_message()
+		await get_tree().create_timer(2.0).timeout
+		
+		GameManager.start_countdown_timer(time_left, _on_minigame_timeout)
+		is_game_active = true
+		# print("Dificultad: %d" % GameManager.get_difficulty())
+		spawn_obstacles()
 
 func spawn_obstacles():
 	obstacle_timer = Timer.new()
@@ -48,24 +50,26 @@ func _on_minigame_timeout():
 	end_game(true)
 	
 func _process(delta):
-        if is_game_active:
-                score += 100.0 / time_left * delta
-                score = clamp(score, 0.0, 100.0)
-                score_label.text = "Puntuación: " + str(round(score))
+		if is_game_active:
+				score += 100.0 / time_left * delta
+				score = clamp(score, 0.0, 100.0)
+				score_label.text = "Puntuación: " + str(round(score))
 
 func end_game(won: bool):
-        is_game_active = false
-        var final_score = round(score)
-        # Mostrar cartel centrado
-        var headline := won ? "¡Superaste la tormenta!" : "¡Ups! ¡Te alcanzó una roca!"
-        result_label.text = "%s\nPuntuación final: %d" % [headline, final_score]
-        result_panel.visible = true
-        start_panel.visible = false
-        GameManager.complete_minigame(won, final_score)
+		is_game_active = false
+		var final_score = round(score)
+		# Mostrar cartel centrado
+		var headline = "¡Ups! ¡Te alcanzó una roca!"
+		if won:
+			headline = "¡Superaste la tormenta!"
+		result_label.text = "%s\nPuntuación final: %d" % [headline, final_score]
+		result_panel.visible = true
+		start_panel.visible = false
+		GameManager.complete_minigame(won, final_score)
 
 func _show_start_message():
-        start_panel.visible = true
-        var timer := get_tree().create_timer(2.0)
-        timer.timeout.connect(func():
-                start_panel.visible = false
-        )
+		start_panel.visible = true
+		var timer := get_tree().create_timer(2.0)
+		timer.timeout.connect(func():
+				start_panel.visible = false
+		)


### PR DESCRIPTION
## Summary
- add a dedicated UI canvas for DodgeTheDrop with styled score, start and result panels
- refresh the start and end messages, including a short intro overlay and improved result summary

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d13a771fa0832dbbf3a7755b8f13c1