### PR TITLE
Add background music to PointerPursuit

### DIFF
--- a/minigames/PointerPursuit/PointerPursuit.gd
+++ b/minigames/PointerPursuit/PointerPursuit.gd
@@ -11,6 +11,7 @@ const BASE_RECT_SIZE := Vector2(90, 64)
 @onready var status_label: Label = $UI/TopBar/HBoxContainer/StatusLabel
 @onready var instructions_label: Label = $UI/Instructions
 @onready var result_label: Label = $UI/ResultLabel
+@onready var music_player: AudioStreamPlayer = $MusicPlayer
 
 var is_game_active := false
 var has_finished := false
@@ -27,16 +28,17 @@ var scale_step := 0.1
 var capture_radius := 40.0
 
 func _ready():
-	Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
-	apply_difficulty_settings()
-	setup_chaser_visual()
-	status_label.text = "Estado: Prepárate"
-	time_label.text = "Tiempo: %.1f" % TOTAL_TIME
-	instructions_label.visible = true
-	result_label.visible = false
-	await get_tree().create_timer(2.0).timeout
-	chaser_body.visible = true
-	start_minigame()
+        Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
+        apply_difficulty_settings()
+        setup_chaser_visual()
+        status_label.text = "Estado: Prepárate"
+        time_label.text = "Tiempo: %.1f" % TOTAL_TIME
+        instructions_label.visible = true
+        result_label.visible = false
+        music_player.play()
+        await get_tree().create_timer(2.0).timeout
+        chaser_body.visible = true
+        start_minigame()
 
 func apply_difficulty_settings():
 	match GameManager.get_difficulty():
@@ -143,12 +145,14 @@ func end_minigame(won: bool, message: String):
 	else:
 		status_label.text = "Estado: Fin del juego"
 
-	result_label.visible = true
-	result_label.text = message + "\nPuntuación: " + str(final_score)
-	chaser_body.visible = false
+        result_label.visible = true
+        result_label.text = message + "\nPuntuación: " + str(final_score)
+        chaser_body.visible = false
+        if music_player.playing:
+                music_player.stop()
 
-	await get_tree().create_timer(2.0).timeout
-	GameManager.complete_minigame(won, final_score)
+        await get_tree().create_timer(2.0).timeout
+        GameManager.complete_minigame(won, final_score)
 
 func calculate_final_score(time_survived: float) -> int:
 	if time_survived < 1.0:

--- a/minigames/PointerPursuit/PointerPursuit.tscn
+++ b/minigames/PointerPursuit/PointerPursuit.tscn
@@ -1,6 +1,7 @@
 [gd_scene load_steps=2 format=3 uid="uid://cmg8h6o0vd7p"]
 
 [ext_resource type="Script" uid="uid://cq1onmhc8x7t5" path="res://minigames/PointerPursuit/PointerPursuit.gd" id="1_6gwtm"]
+[ext_resource type="AudioStream" path="res://minigames/PointerPursuit/assets/Chase.m4a" id="2_a87ox"]
 
 [node name="PointerPursuit" type="Node2D"]
 script = ExtResource("1_6gwtm")
@@ -10,6 +11,10 @@ offset_right = 1152.0
 offset_bottom = 648.0
 mouse_filter = 2
 color = Color(0.0705882, 0.0784314, 0.129412, 1)
+
+[node name="MusicPlayer" type="AudioStreamPlayer" parent="."]
+stream = ExtResource("2_a87ox")
+bus = "Music"
 
 [node name="Chaser" type="Node2D" parent="."]
 position = Vector2(576, 324)


### PR DESCRIPTION
## Summary
- add an AudioStreamPlayer to the PointerPursuit scene configured with the Chase.m4a track
- start the background music when the minigame begins and stop it when it ends

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d14d9f3c80832d94235dea446550f5